### PR TITLE
Fixed installation on linux firefox

### DIFF
--- a/src/linux/firefox/install.sh
+++ b/src/linux/firefox/install.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
 mkdir -p ~/.mozilla/native-messaging-hosts/
-sed -i -r 's+"path": "singlefile_companion_lite"+"path" :"'"$PWD"'\/singlefile_companion_lite"+' singlefile_companion.json
+mkdir -p ~/.singlefile/WebArchives
+
+sed -i 's@singlefile_companion_lite@'/home/$USER'/.singlefile/singlefile_companion_lite@' singlefile_companion.json 
 cp singlefile_companion.json ~/.mozilla/native-messaging-hosts/singlefile_companion.json
+
+cp singlefile_companion_lite ~/.singlefile/singlefile_companion_lite
+cp options.json ~/.singlefile/options.json
+
+chmod 755 ~/.singlefile/singlefile_companion_lite
+
+

--- a/src/linux/firefox/uninstall.sh
+++ b/src/linux/firefox/uninstall.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
 rm -f ~/.mozilla/native-messaging-hosts/singlefile_companion.json
+rm -f ~/.singlefile/singlefile_companion_lite
+rm -f ~/.singlefile/options.json


### PR DESCRIPTION
#3 
The installation script will move executable and config files to ~/.singlefile and modify path in singlefile_companion.json to correspond to proper path, this will not only fix #3 but also increase stability.
How is stability increased?
Let's consider the following scenario: 
User download and install companion then leaves it in Downloads folder, path in singlefile_companion.json points to this directory in Downloads folder after some time user deletes the folder with the companion executable, and the extension stops working correctly, but when companion executable is in a hidden folder risk of accidental deletion drops significantly. 
